### PR TITLE
Feature/get or update a user

### DIFF
--- a/app/views/users.py
+++ b/app/views/users.py
@@ -1,7 +1,7 @@
 # Views for users
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
+from flask_login import current_user, login_required
 from werkzeug.security import generate_password_hash
-from flask import jsonify, request
 from models.user import User
 from app.utils.valid_data import is_valid_password
 
@@ -55,3 +55,18 @@ def create_user():
         return jsonify({"message": "User registered successfully"}), 201
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+@user_bl.get('/users/me', strict_slashes=False)
+@login_required
+def get_specific_user():
+    """GET the logged-in user's information.
+    
+    Just the user's username, household_id and created_at fields are
+    returned.
+    """
+    return jsonify({
+        'username': current_user.username,
+        'household_id': current_user.household_id,
+        'created_at': current_user.created_at,
+    }), 200

--- a/app/views/users.py
+++ b/app/views/users.py
@@ -70,3 +70,43 @@ def get_specific_user():
         'household_id': current_user.household_id,
         'created_at': current_user.created_at,
     }), 200
+
+
+@user_bl.patch('/users/me', strict_slashes=False)
+@login_required
+def update_user():
+    """UPDATES the logged-in user's profile details.
+    
+    Only the username is allowed to be changed for this route.
+    """
+    try:
+        # TODO: catch exception when given type of not application/json
+        data: dict = request.get_json()
+        update_count = 1  # the number of fields that are allowed to be changed
+
+        if not data:
+            return jsonify({"error": "No data provided"}), 400
+
+        username = data.get('username')
+
+        # ensure only certain fields are passed to be updated
+        if update_count < len(data.keys()):
+            return jsonify({'error': f'Only {update_count} required field/s can'
+                            + ' be updated'}), 400
+
+        # Check if username is provided
+        if not username:
+            return jsonify({"error": "Username is required"}), 400
+
+        # Check if username and email already exist
+        user_by_username = User.objects(username=username).first()
+
+        if user_by_username:
+            return jsonify({'error': 'The username is already taken'}), 400
+
+        current_user.username = username
+        current_user.save()
+
+        return jsonify({"message": "User updated"}), 201
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config(object):
     SECRET_KEY = environ.get('SECRET_KEY')
     DEBUG = False
     TESTING = False
-    REMEMBER_COOKIE_DURATION = timedelta(days=60)
+    REMEMBER_COOKIE_DURATION = timedelta(days=30)
 
 
 class ProductionConfig(Config):

--- a/models/user.py
+++ b/models/user.py
@@ -4,6 +4,7 @@ from flask_login import UserMixin
 from mongoengine import Document, ReferenceField, StringField, EmailField, \
                         EmbeddedDocument, EmbeddedDocumentListField, \
                         BooleanField, DateTimeField
+from werkzeug.security import check_password_hash
 
 
 class ShoppingListItem(EmbeddedDocument):
@@ -25,3 +26,14 @@ class User(UserMixin, Document):
 
     created_at = DateTimeField(default=datetime.now(UTC))
     updated_at = DateTimeField(default=datetime.now(UTC))
+
+    def check_password(self, password: str):
+        """Determines if a password matches the hashed password of a user.
+
+        Arg:
+            password(str): the password to check.
+
+        Returns:
+            True if the password is valid, otherwise False.
+        """
+        return check_password_hash(self.password_hash, password)


### PR DESCRIPTION
Allows a user's details be retrieved from the back-end or changed.
Only the user's username, household_id and created_at information are given for the view to get the user's details.
Currently, only the username and password of the user can be changed as the other details are things that don't make sense for the user to change directly. Example, their created_at date (date the user registered) or their household_id. (a view should be provided for a user to join a household)